### PR TITLE
Feat | Add HTML layout wrapping markdown posts content

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,3 @@
+HOST=http://localhost:8000
+WEBSITE_NAME=Your website
+AUTHOR_NAME=Your name

--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,5 @@
 HOST=http://localhost:8000
 WEBSITE_NAME=Your website
 AUTHOR_NAME=Your name
+WEBSITE_LOGO_URL=http://localhost:8080/logo.png
+WEBSITE_DESCRIPTION=My website description

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dotenv = "0.15.0"
 markdown = "1.0.0-alpha.15"
 serde_yaml = "0.9.27"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ An attempt to replicate [Metalsmith's JS library](https://metalsmith.io/) in Rus
 
 ## Requirements
 
+### Repository setup
+
+Duplicate the `.env-example` file at the root into a new `.env` file and edit the values of each variable contained in it accordingly
+
+### Library usage
+
 At this point, you're going to have to annotate your posts with frontmatter data in order for the library to have the necessary information about each post.
 
 Your post header should look like this:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ In order to be able to replace the custom Metalsmith setup I used for Jay.cat, I
 |--- templates
 |----- homepage.html (The main template for the homepage of the site built)
 |----- archive-item.html (The partial for each item rendered in the homepage)
+|----- post.html (The template for each post page)
 |- public
 |--- css
 |----- styles.css (The main stylesheet containing ALL styles)
@@ -49,3 +50,17 @@ This partial has the following placeholders:
 + POST_ITEM_DATE_READABLE_PLACEHOLDER (`{post_date_human_readable}`):
 + POST_ITEM_TITLE_PLACEHOLDER (`{post_title}`):
 + POST_ITEM_EXCERPT_PLACEHOLDER (`{post_excerpt}`):
+
+### Post page template
+
+This template has the following placeholders:
+
++ HOST_PLACEHOLDER (`{host}`)
++ POST_ITEM_DATE_TIMESTAMP_PLACEHOLDER (`{post_date_timestamp}`)
++ POST_ITEM_DATE_READABLE_PLACEHOLDER (`{post_date_human_readable}`)
++ POST_ITEM_TITLE_PLACEHOLDER (`{post_title}`)
++ POST_ITEM_DESCRIPTION_PLACEHOLDER (`{post_description}`)
++ POST_ITEM_CONTENT_PLACEHOLDER (`{post_content}`)
++ POST_ITEM_URL_PLACEHOLDER (`{post_url}`)
++ POST_ITEM_KEYWORDS_PLACEHOLDER (`{post_keywords}`)
++ POST_ITEM_IMAGE_URL_PLACEHOLDER (`{post_image_url}`)

--- a/assets/templates/homepage.html
+++ b/assets/templates/homepage.html
@@ -2,17 +2,24 @@
 <html lang="en">
 
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Your site</title>
-  <link rel="stylesheet" href="css/styles.css">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{website_name}</title>
+    <link rel="stylesheet" href="css/styles.css">
+    
+    <!-- Open Graph data -->
+    <meta property="og:title" content="{website_name}" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="{host}" />
+    <meta property="og:image" content="{website_logo_url}" />
+    <meta property="og:description" content="{website_description}" />
 </head>
 
 <body>
-  <h1>Page Title</h1>
-  <ul class="archive-list">
-    {post_items}
-  </ul>
+    <h1>{website_name}</h1>
+    <ul class="archive-list">
+        {post_items}
+    </ul>
 </body>
 
 </html>

--- a/assets/templates/post.html
+++ b/assets/templates/post.html
@@ -3,10 +3,10 @@
 
 <head>
     <meta charset="utf-8">
-    <title>{post_title} | Your.website</title>
+    <title>{post_title} | {website_name}</title>
     <meta name="description" content="{post_description}">
     <meta name="keywords" content="{post_keywords}">
-    <meta name="author" content="Your name">
+    <meta name="author" content="{author_name}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/css/styles.css">
 

--- a/assets/templates/post.html
+++ b/assets/templates/post.html
@@ -9,6 +9,13 @@
     <meta name="author" content="Your name">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="/css/styles.css">
+
+    <!-- Open Graph data -->
+    <meta property="og:title" content="{post_title}" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="{post_url}" />
+    <meta property="og:image" content="{post_image_url}" />
+    <meta property="og:description" content="{post_description}" /> 
 </head>
 
 <body>

--- a/assets/templates/post.html
+++ b/assets/templates/post.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>{post_title} | Your.website</title>
+    <meta name="description" content="{post_description}">
+    <meta name="keywords" content="{post_keywords}">
+    <meta name="author" content="Your name">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="/css/styles.css">
+</head>
+
+<body>
+    <h1>{post_title}</h1>
+    <time datetime="{post_date_timestamp}" itemprop="datePublished">{post_date_human_readable}</time>
+    {post_content}
+</body>
+
+</html>

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,5 @@
 mod homepage;
+mod post;
 
 use crate::parser;
 use std::{
@@ -28,24 +29,6 @@ fn create_build_dir() -> () {
     }
 }
 
-fn get_permalink_from_title(post_title: String) -> String {
-    let lowercase = post_title.to_lowercase();
-    return str::replace(&lowercase, " ", "-");
-}
-
-fn get_post_full_path(post: &parser::Post) -> String {
-    let build_path = get_build_dir();
-    let post_dir_name = get_permalink_from_title(String::from(&post.frontmatter.title));
-    let full_dir_path = format!("{}/{}", build_path, post_dir_name);
-    return full_dir_path;
-}
-
-fn create_post_file(post: &parser::Post) -> () {
-    let full_path = get_post_full_path(&post);
-    let file_path = format!("{}/index.html", full_path);
-    create_file(&post.html, &file_path)
-}
-
 fn create_file(contents: &str, file_path: &str) -> () {
     let mut file = File::create(file_path).unwrap();
     match write!(file, "{}", contents) {
@@ -56,21 +39,6 @@ fn create_file(contents: &str, file_path: &str) -> () {
             println!("failed to create file, see error: {}", msg);
         }
     }
-}
-
-fn create_post_dir_and_file(post: &parser::Post) -> () {
-    let full_dir_path = get_post_full_path(&post);
-
-    match fs::create_dir(full_dir_path) {
-        Ok(_) => {
-            // println!("created dir succesfully");
-        }
-        Err(msg) => {
-            println!("failed to create directory, see error: {}", msg);
-        }
-    }
-
-    create_post_file(post);
 }
 
 fn add_public_assets_to_build() -> () {
@@ -89,7 +57,7 @@ pub fn build(posts: &Vec<parser::Post>) -> () {
     create_build_dir();
 
     for post in posts {
-        create_post_dir_and_file(&post);
+        post::create_post_dir_and_file(&post);
     }
 
     homepage::create_homepage(&posts);

--- a/src/builder/homepage.rs
+++ b/src/builder/homepage.rs
@@ -15,6 +15,7 @@ const HOST_PLACEHOLDER: &str = "{host}";
 const WEBSITE_NAME: &str = "{website_name}";
 const WEBSITE_LOGO_URL: &str = "{website_logo_url}";
 const WEBSITE_DESCRIPTION: &str = "{website_description}";
+const AUTHOR_NAME: &str = "{author_name}";
 
 // Homepage Item partial
 const POST_ITEM_LINK_PLACEHOLDER: &str = "{post_link}";
@@ -62,12 +63,14 @@ fn get_home_template() -> String {
     let website_name: String = dotenv::var("WEBSITE_NAME").expect("WEBSITE_NAME environment variable must be set");
     let website_logo_url: String = dotenv::var("WEBSITE_LOGO_URL").expect("WEBSITE_LOGO_URL environment variable must be set");
     let website_description: String = dotenv::var("WEBSITE_DESCRIPTION").expect("WEBSITE_DESCRIPTION environment variable must be set");
+    let author_name: String = dotenv::var("AUTHOR_NAME").expect("AUTHOR_NAME environment variable must be set");
     let mut template_contents = fs::read_to_string(HOMEPAGE_TEMPLATE_FILE_PATH).unwrap();
     template_contents = template_contents
         .replace(&HOST_PLACEHOLDER, &host)
         .replace(&WEBSITE_NAME, &website_name)
         .replace(&WEBSITE_LOGO_URL, &website_logo_url)
-        .replace(&WEBSITE_DESCRIPTION, &website_description);
+        .replace(&WEBSITE_DESCRIPTION, &website_description)
+    .replace(&AUTHOR_NAME, &author_name);
     return template_contents;
 }
 

--- a/src/builder/homepage.rs
+++ b/src/builder/homepage.rs
@@ -1,12 +1,10 @@
 use std::fs;
 
-use crate::builder::get_build_dir;
+use crate::builder::{create_file, get_build_dir};
 use crate::parser;
 
-use super::create_file;
-
-// Const (Move to .env)
-const HOST: &str = "localhost:8000";
+// TO-DO: Const (Move to .env)
+const HOST: &str = "http://localhost:8000";
 
 // Template filepaths
 const HOMEPAGE_TEMPLATE_FILE_PATH: &str = "./assets/templates/homepage.html";
@@ -38,7 +36,7 @@ fn get_posts_markup(posts: &Vec<parser::Post>) -> String {
     let mut markup: String = "".to_owned();
 
     for post in posts {
-        let post_link = &format!("{}/{}/", HOST, post.full_path);
+        let post_link = &format!("{}/{}/", HOST, post.permalink);
         let post_date = &post.frontmatter.date;
 
         let mut post_description = "";

--- a/src/builder/homepage.rs
+++ b/src/builder/homepage.rs
@@ -1,10 +1,8 @@
 use std::fs;
+use dotenv;
 
 use crate::builder::{create_file, get_build_dir};
 use crate::parser;
-
-// TO-DO: Const (Move to .env)
-const HOST: &str = "http://localhost:8000";
 
 // Template filepaths
 const HOMEPAGE_TEMPLATE_FILE_PATH: &str = "./assets/templates/homepage.html";
@@ -34,9 +32,10 @@ pub fn create_homepage(posts: &Vec<parser::Post>) -> () {
 fn get_posts_markup(posts: &Vec<parser::Post>) -> String {
     let item_template = fs::read_to_string(HOMEPAGE_POST_PARTIAL_FILE_PATH).unwrap();
     let mut markup: String = "".to_owned();
+    let host: String = dotenv::var("HOST").expect("HOST environment variable must be set");
 
     for post in posts {
-        let post_link = &format!("{}/{}/", HOST, post.permalink);
+        let post_link = &format!("{}/{}/", host, post.permalink);
         let post_date = &post.frontmatter.date;
 
         let mut post_description = "";
@@ -56,8 +55,9 @@ fn get_posts_markup(posts: &Vec<parser::Post>) -> String {
 }
 
 fn get_home_template() -> String {
+    let host: String = dotenv::var("HOST").expect("HOST environment variable must be set");
     let mut template_contents = fs::read_to_string(HOMEPAGE_TEMPLATE_FILE_PATH).unwrap();
-    template_contents = template_contents.replace(&HOST_PLACEHOLDER, &HOST);
+    template_contents = template_contents.replace(&HOST_PLACEHOLDER, &host);
     return template_contents;
 }
 

--- a/src/builder/homepage.rs
+++ b/src/builder/homepage.rs
@@ -48,14 +48,8 @@ fn get_posts_markup(posts: &Vec<parser::Post>) -> String {
 
         let item_markup = &item_template
             .replace(POST_ITEM_LINK_PLACEHOLDER, &post_link)
-            .replace(
-                POST_ITEM_DATE_TIMESTAMP_PLACEHOLDER,
-                post_date,
-            )
-            .replace(
-                POST_ITEM_DATE_READABLE_PLACEHOLDER,
-                post_date,
-            )
+            .replace(POST_ITEM_DATE_TIMESTAMP_PLACEHOLDER, post_date)
+            .replace(POST_ITEM_DATE_READABLE_PLACEHOLDER, post_date)
             .replace(POST_ITEM_TITLE_PLACEHOLDER, &post.frontmatter.title)
             .replace(POST_ITEM_EXCERPT_PLACEHOLDER, post_description);
         markup += item_markup;

--- a/src/builder/homepage.rs
+++ b/src/builder/homepage.rs
@@ -12,6 +12,9 @@ const HOMEPAGE_POST_PARTIAL_FILE_PATH: &str = "./assets/templates/archive-item.h
 // Homepage
 const POST_ITEMS_PLACEHOLDER: &str = "{post_items}";
 const HOST_PLACEHOLDER: &str = "{host}";
+const WEBSITE_NAME: &str = "{website_name}";
+const WEBSITE_LOGO_URL: &str = "{website_logo_url}";
+const WEBSITE_DESCRIPTION: &str = "{website_description}";
 
 // Homepage Item partial
 const POST_ITEM_LINK_PLACEHOLDER: &str = "{post_link}";
@@ -56,8 +59,15 @@ fn get_posts_markup(posts: &Vec<parser::Post>) -> String {
 
 fn get_home_template() -> String {
     let host: String = dotenv::var("HOST").expect("HOST environment variable must be set");
+    let website_name: String = dotenv::var("WEBSITE_NAME").expect("WEBSITE_NAME environment variable must be set");
+    let website_logo_url: String = dotenv::var("WEBSITE_LOGO_URL").expect("WEBSITE_LOGO_URL environment variable must be set");
+    let website_description: String = dotenv::var("WEBSITE_DESCRIPTION").expect("WEBSITE_DESCRIPTION environment variable must be set");
     let mut template_contents = fs::read_to_string(HOMEPAGE_TEMPLATE_FILE_PATH).unwrap();
-    template_contents = template_contents.replace(&HOST_PLACEHOLDER, &host);
+    template_contents = template_contents
+        .replace(&HOST_PLACEHOLDER, &host)
+        .replace(&WEBSITE_NAME, &website_name)
+        .replace(&WEBSITE_LOGO_URL, &website_logo_url)
+        .replace(&WEBSITE_DESCRIPTION, &website_description);
     return template_contents;
 }
 

--- a/src/builder/post.rs
+++ b/src/builder/post.rs
@@ -9,6 +9,8 @@ const POST_TEMPLATE_FILE_PATH: &str = "./assets/templates/post.html";
 
 // Templates placeholders
 const HOST_PLACEHOLDER: &str = "{host}";
+const WEBSITE_NAME: &str = "{website_name}";
+const AUTHOR_NAME: &str = "{author_name}";
 const POST_ITEM_DATE_TIMESTAMP_PLACEHOLDER: &str = "{post_date_timestamp}";
 const POST_ITEM_DATE_READABLE_PLACEHOLDER: &str = "{post_date_human_readable}";
 const POST_ITEM_TITLE_PLACEHOLDER: &str = "{post_title}";
@@ -20,6 +22,8 @@ const POST_ITEM_IMAGE_URL_PLACEHOLDER: &str = "{post_image_url}";
 
 fn wrap_post_with_layout(post: &parser::Post) -> String {
     let host: String = dotenv::var("HOST").expect("HOST environment variable must be set");
+    let website_name: String = dotenv::var("WEBSITE_NAME").expect("WEBSITE_NAME environment variable must be set");
+    let author_name: String = dotenv::var("AUTHOR_NAME").expect("AUTHOR_NAME environment variable must be set");
     let image = &format!("{}/img/logo.png", host); // TO-DO: Implement support for image in frontmatter parser
     let post_link = &format!("{}/{}/", host, post.full_path);
     let mut post_description = "";
@@ -36,6 +40,8 @@ fn wrap_post_with_layout(post: &parser::Post) -> String {
 
     let post_markup = post_template
         .replace(HOST_PLACEHOLDER, &host)
+        .replace(WEBSITE_NAME, &website_name)
+        .replace(AUTHOR_NAME, &author_name)
         .replace(POST_ITEM_DATE_TIMESTAMP_PLACEHOLDER, &post.frontmatter.date)
         .replace(
             POST_ITEM_DATE_READABLE_PLACEHOLDER,

--- a/src/builder/post.rs
+++ b/src/builder/post.rs
@@ -1,0 +1,38 @@
+use std::fs;
+
+use crate::parser;
+
+use super::{create_file, get_build_dir};
+
+fn get_permalink_from_title(post_title: String) -> String {
+    let lowercase = post_title.to_lowercase();
+    return str::replace(&lowercase, " ", "-");
+}
+
+fn get_post_full_path(post: &parser::Post) -> String {
+    let build_path = get_build_dir();
+    let post_dir_name = get_permalink_from_title(String::from(&post.frontmatter.title));
+    let full_dir_path = format!("{}/{}", build_path, post_dir_name);
+    return full_dir_path;
+}
+
+fn create_post_file(post: &parser::Post) -> () {
+    let full_path = get_post_full_path(&post);
+    let file_path = format!("{}/index.html", full_path);
+    create_file(&post.html, &file_path)
+}
+
+pub fn create_post_dir_and_file(post: &parser::Post) -> () {
+    let full_dir_path = get_post_full_path(&post);
+
+    match fs::create_dir(full_dir_path) {
+        Ok(_) => {
+            // println!("created dir succesfully");
+        }
+        Err(msg) => {
+            println!("failed to create directory, see error: {}", msg);
+        }
+    }
+
+    create_post_file(post);
+}

--- a/src/builder/post.rs
+++ b/src/builder/post.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use dotenv;
 
 use crate::builder::{create_file, get_build_dir};
 use crate::parser;
@@ -18,8 +19,7 @@ const POST_ITEM_KEYWORDS_PLACEHOLDER: &str = "{post_keywords}";
 const POST_ITEM_IMAGE_URL_PLACEHOLDER: &str = "{post_image_url}";
 
 fn wrap_post_with_layout(post: &parser::Post) -> String {
-    // TO-DO: Const (Move to .env)
-    let host = "http://localhost:8000";
+    let host: String = dotenv::var("HOST").expect("HOST environment variable must be set");
     let image = &format!("{}/img/logo.png", host); // TO-DO: Implement support for image in frontmatter parser
     let post_link = &format!("{}/{}/", host, post.full_path);
     let mut post_description = "";
@@ -35,7 +35,7 @@ fn wrap_post_with_layout(post: &parser::Post) -> String {
     let post_template = fs::read_to_string(POST_TEMPLATE_FILE_PATH).unwrap();
 
     let post_markup = post_template
-        .replace(HOST_PLACEHOLDER, host)
+        .replace(HOST_PLACEHOLDER, &host)
         .replace(POST_ITEM_DATE_TIMESTAMP_PLACEHOLDER, &post.frontmatter.date)
         .replace(
             POST_ITEM_DATE_READABLE_PLACEHOLDER,

--- a/src/builder/post.rs
+++ b/src/builder/post.rs
@@ -1,25 +1,68 @@
 use std::fs;
 
+use crate::builder::{create_file, get_build_dir};
 use crate::parser;
 
-use super::{create_file, get_build_dir};
+// Template filepaths
+const POST_TEMPLATE_FILE_PATH: &str = "./assets/templates/post.html";
 
-fn get_permalink_from_title(post_title: String) -> String {
-    let lowercase = post_title.to_lowercase();
-    return str::replace(&lowercase, " ", "-");
+// Templates placeholders
+const HOST_PLACEHOLDER: &str = "{host}";
+const POST_ITEM_DATE_TIMESTAMP_PLACEHOLDER: &str = "{post_date_timestamp}";
+const POST_ITEM_DATE_READABLE_PLACEHOLDER: &str = "{post_date_human_readable}";
+const POST_ITEM_TITLE_PLACEHOLDER: &str = "{post_title}";
+const POST_ITEM_DESCRIPTION_PLACEHOLDER: &str = "{post_description}";
+const POST_ITEM_CONTENT_PLACEHOLDER: &str = "{post_content}";
+const POST_ITEM_URL_PLACEHOLDER: &str = "{post_url}";
+const POST_ITEM_KEYWORDS_PLACEHOLDER: &str = "{post_keywords}";
+const POST_ITEM_IMAGE_URL_PLACEHOLDER: &str = "{post_image_url}";
+
+fn wrap_post_with_layout(post: &parser::Post) -> String {
+    // TO-DO: Const (Move to .env)
+    let host = "http://localhost:8000";
+    let image = &format!("{}/img/logo.png", host); // TO-DO: Implement support for image in frontmatter parser
+    let post_link = &format!("{}/{}/", host, post.full_path);
+    let mut post_description = "";
+    if let Some(description) = &post.frontmatter.description {
+        post_description = &description;
+    }
+
+    let mut post_keywords = "";
+    if let Some(keywords) = &post.frontmatter.keywords {
+        post_keywords = &keywords;
+    }
+
+    let post_template = fs::read_to_string(POST_TEMPLATE_FILE_PATH).unwrap();
+
+    let post_markup = post_template
+        .replace(HOST_PLACEHOLDER, host)
+        .replace(POST_ITEM_DATE_TIMESTAMP_PLACEHOLDER, &post.frontmatter.date)
+        .replace(
+            POST_ITEM_DATE_READABLE_PLACEHOLDER,
+            &post.frontmatter.date.replace('-', "/"),
+        )
+        .replace(POST_ITEM_TITLE_PLACEHOLDER, &post.frontmatter.title)
+        .replace(POST_ITEM_DESCRIPTION_PLACEHOLDER, post_description)
+        .replace(POST_ITEM_CONTENT_PLACEHOLDER, &post.html)
+        .replace(POST_ITEM_URL_PLACEHOLDER, post_link)
+        .replace(POST_ITEM_KEYWORDS_PLACEHOLDER, post_keywords)
+        .replace(POST_ITEM_IMAGE_URL_PLACEHOLDER, image);
+
+    return post_markup;
 }
 
 fn get_post_full_path(post: &parser::Post) -> String {
     let build_path = get_build_dir();
-    let post_dir_name = get_permalink_from_title(String::from(&post.frontmatter.title));
-    let full_dir_path = format!("{}/{}", build_path, post_dir_name);
+    let full_dir_path = format!("{}/{}", build_path, post.permalink);
     return full_dir_path;
 }
 
 fn create_post_file(post: &parser::Post) -> () {
     let full_path = get_post_full_path(&post);
     let file_path = format!("{}/index.html", full_path);
-    create_file(&post.html, &file_path)
+
+    let wrapped_post_contents = wrap_post_with_layout(&post);
+    create_file(&wrapped_post_contents, &file_path)
 }
 
 pub fn create_post_dir_and_file(post: &parser::Post) -> () {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,21 +7,27 @@ use markdown::{mdast::Node, CompileOptions, Constructs, Options, ParseOptions};
 
 #[derive(Debug)]
 pub struct FrontmatterData {
-    pub title: String,
+    pub date: String,
     pub description: Option<String>,
     pub keywords: Option<String>,
-    pub date: String,
+    pub title: String,
 }
 
 #[derive(Debug)]
 pub struct Post {
-    pub full_path: String,
     pub file_name: String,
-    pub html: String,
     pub frontmatter: FrontmatterData,
+    pub full_path: String,
+    pub html: String,
+    pub permalink: String,
 }
 
 const POSTS_FILE_PATH: &str = "/home/jay/code/rusty-smith/posts";
+
+fn get_permalink_from_title(post_title: &String) -> String {
+    let lowercase = post_title.to_lowercase();
+    return str::replace(&lowercase, " ", "-");
+}
 
 fn parse_html(post_markdown: &String) -> String {
     let parse_options = Options {
@@ -123,12 +129,14 @@ fn parse_post(post_path: DirEntry) -> Result<Post, String> {
             ))
         }
     }
+    let permalink = get_permalink_from_title(&parsed_post_frontmatter.title);
 
     let new_post = Post {
-        full_path: String::from(full_path),
         file_name,
-        html: parsed_post_html,
         frontmatter: parsed_post_frontmatter,
+        full_path: String::from(full_path),
+        html: parsed_post_html,
+        permalink: permalink,
     };
     return Ok(new_post);
 }


### PR DESCRIPTION
Add post pages functionality by introducing a new submodule (post.rs) that composes it based on a new template:
+ post.html

Also introduces the usage of dotenv files, plus a README section for it.