### PR TITLE
feat: additional features to complete feature parity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Required environment variables for rusty-smith
+# Copy this file to .env and fill in your values
+
+# Site URL (no trailing slash)
+HOST=https://example.com
+
+# Site name displayed in navigation and titles
+WEBSITE_NAME="My Site"
+
+# Author name for meta tags
+AUTHOR_NAME="Your Name"
+
+# URL to your site logo (used in Open Graph and Twitter cards)
+WEBSITE_LOGO_URL=https://example.com/img/logo.png
+
+# Site description for meta tags
+WEBSITE_DESCRIPTION="A description of your site"
+
+# Twitter handle for Twitter cards (include the @)
+TWITTER_HANDLE="@yourusername"

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ Cargo.lock
 # Ignore posts md files
 posts
 
+# Ignore pages (use pages.example as reference)
+pages
+
 # Ignore build directory
 build
 

--- a/assets/templates/page.html
+++ b/assets/templates/page.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{page_title} | {website_name}</title>
+    <meta name="description" content="{page_description}">
+    <meta name="author" content="{author_name}">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Twitter Card data -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{page_title} | {website_name}">
+    <meta name="twitter:description" content="{page_description}">
+    <meta name="twitter:image" content="{website_logo_url}">
+
+    <!-- Open Graph data -->
+    <meta property="og:title" content="{page_title} | {website_name}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{page_url}" />
+    <meta property="og:image" content="{website_logo_url}" />
+    <meta property="og:description" content="{page_description}" />
+
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
+    <link rel="stylesheet" href="/css/styles.css?v=1.0">
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="page {page_slug}">
+        <header>
+            <nav class="navigation">
+                <a class="backHome" href="{host}">{website_name}</a>
+            </nav>
+        </header>
+        <main>
+            {page_content}
+        </main>
+    </div>
+</body>
+</html>

--- a/assets/templates/search.html
+++ b/assets/templates/search.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>{website_name} | Search page</title>
+    <meta name="description" content="{website_name}">
+    <meta name="author" content="{author_name}">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Twitter Card data -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{website_name} | Search page">
+    <meta name="twitter:description" content="{website_description}">
+    <meta name="twitter:creator" content="{twitter_handle}">
+    <meta name="twitter:image" content="{website_logo_url}">
+
+    <!-- Open Graph data -->
+    <meta property="og:title" content="{website_name} | Search page" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="{host}/search" />
+    <meta property="og:image" content="{website_logo_url}" />
+    <meta property="og:description" content="{website_description}" />
+
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
+    <link rel="stylesheet" href="/css/styles.css?v=1.0">
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900&display=swap" rel="stylesheet">
+</head>
+
+<body>
+    <div class="page search-page archive">
+        <header>
+            <nav class="navigation">
+                <div class="links">
+                    <a class="backHome" href="{host}">{website_name}</a><span class="divider" aria-hidden="true">/</span><a
+                        class="about-me" href="{host}/about-me">About me</a>
+                </div>
+                <div class="search-box-container">
+                    <svg class="search-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+                        width="48" height="48">
+                        <path d="M0 0h24v24H0z" fill="none" />
+                        <path
+                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0016 9.5 6.5 6.5 0 109.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+                    </svg>
+                    <form id="nav-search-form" method="get" action="/search">
+                        <input name="query" id="search" class="search-bar" type="search" />
+                    </form>
+                </div>
+            </nav>
+        </header>
+        <main>
+            <h1>Search results:</h1>
+            <ul class="archive-list"></ul>
+        </main>
+    </div>
+    <script>const resources = {resources};</script>
+    <script src="/js/search.js"></script>
+</body>
+
+</html>

--- a/pages.example/about-me.md
+++ b/pages.example/about-me.md
@@ -1,0 +1,22 @@
+---
+title: About me
+description: A short description about yourself for meta tags
+---
+
+# About Me
+
+Welcome to my site! This is a sample about page.
+
+## Who am I?
+
+Write a bit about yourself here.
+
+## Contact
+
+You can reach me at:
+- Email: your@email.com
+- Twitter: [@yourhandle](https://twitter.com/yourhandle)
+
+## What is this site about?
+
+Describe what visitors can expect to find on your site.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,6 +10,7 @@ pub fn build() -> Result<(), Box<dyn std::error::Error>> {
     pipeline.add_plugin(PostsPlugin::new());
     pipeline.add_plugin(PostPlugin::new());
     pipeline.add_plugin(HomepagePlugin::new());
+    pipeline.add_plugin(PagesPlugin::new());
     pipeline.add_plugin(FeedPlugin::new());
     pipeline.add_plugin(SitemapPlugin::new());
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -11,6 +11,7 @@ pub fn build() -> Result<(), Box<dyn std::error::Error>> {
     pipeline.add_plugin(PostPlugin::new());
     pipeline.add_plugin(HomepagePlugin::new());
     pipeline.add_plugin(PagesPlugin::new());
+    pipeline.add_plugin(SearchPlugin::new());
     pipeline.add_plugin(FeedPlugin::new());
     pipeline.add_plugin(SitemapPlugin::new());
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,10 +1,20 @@
 use std::collections::HashMap;
 use crate::parser::Post;
 
+/// Represents a static page (like about, contact, etc.)
+#[derive(Debug)]
+pub struct Page {
+    pub title: String,
+    pub description: Option<String>,
+    pub slug: String,
+    pub html: String,
+}
+
 /// Represents the site's metadata and content during the build process
 #[derive(Debug)]
 pub struct Site {
     pub posts: Vec<Post>,
+    pub pages: Vec<Page>,
     pub metadata: HashMap<String, String>,
 }
 
@@ -12,6 +22,7 @@ impl Site {
     pub fn new() -> Self {
         Site {
             posts: Vec::new(),
+            pages: Vec::new(),
             metadata: HashMap::new(),
         }
     }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -4,6 +4,7 @@ pub mod homepage;
 pub mod pages;
 pub mod post;
 pub mod posts;
+pub mod search;
 pub mod sitemap;
 
 pub use build::BuildPlugin;
@@ -12,4 +13,5 @@ pub use homepage::HomepagePlugin;
 pub use pages::PagesPlugin;
 pub use post::PostPlugin;
 pub use posts::PostsPlugin;
+pub use search::SearchPlugin;
 pub use sitemap::SitemapPlugin; 

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,6 +1,7 @@
 pub mod build;
 pub mod feed;
 pub mod homepage;
+pub mod pages;
 pub mod post;
 pub mod posts;
 pub mod sitemap;
@@ -8,6 +9,7 @@ pub mod sitemap;
 pub use build::BuildPlugin;
 pub use feed::FeedPlugin;
 pub use homepage::HomepagePlugin;
+pub use pages::PagesPlugin;
 pub use post::PostPlugin;
 pub use posts::PostsPlugin;
 pub use sitemap::SitemapPlugin; 

--- a/src/plugins/pages/mod.rs
+++ b/src/plugins/pages/mod.rs
@@ -1,0 +1,162 @@
+use std::env;
+use std::fs::{self, DirEntry, File};
+use std::io::Write;
+
+use dotenv;
+use markdown::{mdast::Node, CompileOptions, Constructs, Options, ParseOptions};
+
+use crate::plugin::{Page, Plugin, Site};
+
+const PAGES_DIR: &str = "pages";
+const PAGE_TEMPLATE_FILE_PATH: &str = "./assets/templates/page.html";
+
+// Template placeholders
+const PAGE_TITLE_PLACEHOLDER: &str = "{page_title}";
+const PAGE_DESCRIPTION_PLACEHOLDER: &str = "{page_description}";
+const PAGE_CONTENT_PLACEHOLDER: &str = "{page_content}";
+const PAGE_URL_PLACEHOLDER: &str = "{page_url}";
+const PAGE_SLUG_PLACEHOLDER: &str = "{page_slug}";
+const HOST_PLACEHOLDER: &str = "{host}";
+const WEBSITE_NAME_PLACEHOLDER: &str = "{website_name}";
+const WEBSITE_LOGO_URL_PLACEHOLDER: &str = "{website_logo_url}";
+const AUTHOR_NAME_PLACEHOLDER: &str = "{author_name}";
+
+pub struct PagesPlugin;
+
+impl PagesPlugin {
+    pub fn new() -> Self {
+        PagesPlugin
+    }
+
+    fn parse_html(markdown_content: &str) -> String {
+        let parse_options = Options {
+            compile: CompileOptions {
+                allow_dangerous_html: true,
+                ..CompileOptions::default()
+            },
+            parse: ParseOptions {
+                constructs: Constructs {
+                    frontmatter: true,
+                    ..Constructs::default()
+                },
+                ..ParseOptions::default()
+            },
+        };
+        markdown::to_html_with_options(markdown_content, &parse_options).unwrap_or_default()
+    }
+
+    fn parse_frontmatter(markdown_content: &str) -> (String, Option<String>) {
+        let parse_options = ParseOptions {
+            constructs: Constructs {
+                frontmatter: true,
+                ..Constructs::gfm()
+            },
+            ..ParseOptions::default()
+        };
+
+        let ast = markdown::to_mdast(markdown_content, &parse_options).ok();
+
+        if let Some(node) = ast {
+            if let Some(children) = node.children() {
+                if let Some(Node::Yaml(yaml)) = children.first() {
+                    let parsed: std::collections::BTreeMap<String, String> =
+                        serde_yaml::from_str(&yaml.value).unwrap_or_default();
+
+                    let title = parsed.get("title").cloned().unwrap_or_default();
+                    let description = parsed.get("description").cloned();
+
+                    return (title, description);
+                }
+            }
+        }
+
+        (String::new(), None)
+    }
+
+    fn get_slug_from_filename(filename: &str) -> String {
+        filename.trim_end_matches(".md").to_string()
+    }
+
+    fn parse_page(entry: DirEntry) -> Option<Page> {
+        let path = entry.path();
+        let filename = entry.file_name().to_str()?.to_string();
+
+        if !filename.ends_with(".md") {
+            return None;
+        }
+
+        let content = fs::read_to_string(&path).ok()?;
+        let (title, description) = Self::parse_frontmatter(&content);
+        let html = Self::parse_html(&content);
+        let slug = Self::get_slug_from_filename(&filename);
+
+        Some(Page {
+            title,
+            description,
+            slug,
+            html,
+        })
+    }
+}
+
+impl Plugin for PagesPlugin {
+    fn name(&self) -> &str {
+        "pages"
+    }
+
+    fn run(&self, site: &mut Site) -> Result<(), Box<dyn std::error::Error>> {
+        // Get environment variables
+        let host = dotenv::var("HOST").expect("HOST environment variable must be set");
+        let website_name =
+            dotenv::var("WEBSITE_NAME").expect("WEBSITE_NAME environment variable must be set");
+        let website_logo_url = dotenv::var("WEBSITE_LOGO_URL")
+            .expect("WEBSITE_LOGO_URL environment variable must be set");
+        let author_name =
+            dotenv::var("AUTHOR_NAME").expect("AUTHOR_NAME environment variable must be set");
+
+        // Read the page template
+        let page_template = fs::read_to_string(PAGE_TEMPLATE_FILE_PATH)?;
+
+        // Get build directory
+        let current_path = env::current_dir()?.into_os_string();
+        let current_path_str = current_path.to_str().ok_or("Invalid path")?;
+        let build_dir = format!("{}/build", current_path_str);
+
+        // Read and process all pages
+        let pages_dir = fs::read_dir(PAGES_DIR)?;
+
+        for entry in pages_dir.flatten() {
+            if let Some(page) = Self::parse_page(entry) {
+                // Create output directory
+                let page_dir = format!("{}/{}", build_dir, page.slug);
+                fs::create_dir_all(&page_dir)?;
+
+                // Apply template
+                let page_url = format!("{}/{}/", host, page.slug);
+                let page_html = page_template
+                    .replace(PAGE_TITLE_PLACEHOLDER, &page.title)
+                    .replace(
+                        PAGE_DESCRIPTION_PLACEHOLDER,
+                        page.description.as_deref().unwrap_or(""),
+                    )
+                    .replace(PAGE_CONTENT_PLACEHOLDER, &page.html)
+                    .replace(PAGE_URL_PLACEHOLDER, &page_url)
+                    .replace(PAGE_SLUG_PLACEHOLDER, &page.slug)
+                    .replace(HOST_PLACEHOLDER, &host)
+                    .replace(WEBSITE_NAME_PLACEHOLDER, &website_name)
+                    .replace(WEBSITE_LOGO_URL_PLACEHOLDER, &website_logo_url)
+                    .replace(AUTHOR_NAME_PLACEHOLDER, &author_name);
+
+                // Write output file
+                let output_path = format!("{}/index.html", page_dir);
+                let mut file = File::create(output_path)?;
+                write!(file, "{}", page_html)?;
+
+                // Store page in site for sitemap
+                site.pages.push(page);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/plugins/post/mod.rs
+++ b/src/plugins/post/mod.rs
@@ -20,6 +20,7 @@ const POST_ITEM_CONTENT_PLACEHOLDER: &str = "{post_content}";
 const POST_ITEM_URL_PLACEHOLDER: &str = "{post_url}";
 const POST_ITEM_KEYWORDS_PLACEHOLDER: &str = "{post_keywords}";
 const POST_ITEM_IMAGE_URL_PLACEHOLDER: &str = "{post_image_url}";
+const THEME_CLASS_PLACEHOLDER: &str = "{theme_class}";
 
 pub struct PostPlugin;
 
@@ -65,7 +66,8 @@ impl Plugin for PostPlugin {
                 .replace(POST_ITEM_CONTENT_PLACEHOLDER, &post.html)
                 .replace(POST_ITEM_URL_PLACEHOLDER, &post.permalink)
                 .replace(POST_ITEM_KEYWORDS_PLACEHOLDER, &post.frontmatter.keywords.as_deref().unwrap_or(""))
-                .replace(POST_ITEM_IMAGE_URL_PLACEHOLDER, &format!("{}/img/logo.png", host));
+                .replace(POST_ITEM_IMAGE_URL_PLACEHOLDER, &format!("{}/img/logo.png", host))
+                .replace(THEME_CLASS_PLACEHOLDER, post.frontmatter.theme_class());
 
             write!(file, "{}", post_html)?;
         }

--- a/src/plugins/posts.rs
+++ b/src/plugins/posts.rs
@@ -18,6 +18,9 @@ impl Plugin for PostsPlugin {
         // Read posts from the posts directory
         let mut posts = parser::get_posts();
 
+        // Filter out drafts (posts with publish: draft)
+        posts.retain(|post| !post.frontmatter.is_draft());
+
         // Sort posts by date in reverse chronological order (newest first)
         // Date format is "YYYY-MM-DD" so lexicographic comparison works correctly
         posts.sort_by(|a, b| b.frontmatter.date.cmp(&a.frontmatter.date));

--- a/src/plugins/search/mod.rs
+++ b/src/plugins/search/mod.rs
@@ -1,0 +1,106 @@
+use std::env;
+use std::fs::{self, File};
+use std::io::Write;
+
+use dotenv;
+
+use crate::plugin::{Plugin, Site};
+
+const SEARCH_TEMPLATE_FILE_PATH: &str = "./assets/templates/search.html";
+
+// Template placeholders
+const HOST_PLACEHOLDER: &str = "{host}";
+const WEBSITE_NAME_PLACEHOLDER: &str = "{website_name}";
+const WEBSITE_DESCRIPTION_PLACEHOLDER: &str = "{website_description}";
+const WEBSITE_LOGO_URL_PLACEHOLDER: &str = "{website_logo_url}";
+const AUTHOR_NAME_PLACEHOLDER: &str = "{author_name}";
+const TWITTER_HANDLE_PLACEHOLDER: &str = "{twitter_handle}";
+const RESOURCES_PLACEHOLDER: &str = "{resources}";
+
+pub struct SearchPlugin;
+
+impl SearchPlugin {
+    pub fn new() -> Self {
+        SearchPlugin
+    }
+
+    fn format_date(date: &str) -> String {
+        // Input: "YYYY-MM-DD", Output: "YYYY/MM/DD"
+        date.replace("-", "/")
+    }
+
+    fn generate_search_json(site: &Site, host: &str) -> String {
+        let items: Vec<String> = site
+            .posts
+            .iter()
+            .map(|post| {
+                let url = format!("{}/{}/", host, post.permalink);
+                let date_timestamp = &post.frontmatter.date;
+                let date_human_readable = Self::format_date(date_timestamp);
+                let excerpt = post
+                    .frontmatter
+                    .description
+                    .as_deref()
+                    .unwrap_or("")
+                    .replace("\"", "\\\"");
+                let title = post.frontmatter.title.replace("\"", "\\\"");
+
+                format!(
+                    r#"{{"title":"{}","url":"{}","dateTimestamp":"{}","dateHumanReadable":"{}","excerpt":"{}"}}"#,
+                    title, url, date_timestamp, date_human_readable, excerpt
+                )
+            })
+            .collect();
+
+        format!("[{}]", items.join(","))
+    }
+}
+
+impl Plugin for SearchPlugin {
+    fn name(&self) -> &str {
+        "search"
+    }
+
+    fn run(&self, site: &mut Site) -> Result<(), Box<dyn std::error::Error>> {
+        // Get environment variables
+        let host = dotenv::var("HOST").expect("HOST environment variable must be set");
+        let website_name =
+            dotenv::var("WEBSITE_NAME").expect("WEBSITE_NAME environment variable must be set");
+        let website_description = dotenv::var("WEBSITE_DESCRIPTION")
+            .expect("WEBSITE_DESCRIPTION environment variable must be set");
+        let website_logo_url = dotenv::var("WEBSITE_LOGO_URL")
+            .expect("WEBSITE_LOGO_URL environment variable must be set");
+        let author_name =
+            dotenv::var("AUTHOR_NAME").expect("AUTHOR_NAME environment variable must be set");
+        let twitter_handle =
+            dotenv::var("TWITTER_HANDLE").expect("TWITTER_HANDLE environment variable must be set");
+
+        // Read the search template
+        let search_template = fs::read_to_string(SEARCH_TEMPLATE_FILE_PATH)?;
+
+        // Generate search JSON from posts
+        let resources_json = Self::generate_search_json(site, &host);
+
+        // Replace placeholders
+        let search_html = search_template
+            .replace(HOST_PLACEHOLDER, &host)
+            .replace(WEBSITE_NAME_PLACEHOLDER, &website_name)
+            .replace(WEBSITE_DESCRIPTION_PLACEHOLDER, &website_description)
+            .replace(WEBSITE_LOGO_URL_PLACEHOLDER, &website_logo_url)
+            .replace(AUTHOR_NAME_PLACEHOLDER, &author_name)
+            .replace(TWITTER_HANDLE_PLACEHOLDER, &twitter_handle)
+            .replace(RESOURCES_PLACEHOLDER, &resources_json);
+
+        // Create the search directory and write the file
+        let current_path = env::current_dir()?.into_os_string();
+        let current_path_str = current_path.to_str().ok_or("Invalid path")?;
+        let search_dir = format!("{}/build/search", current_path_str);
+        fs::create_dir_all(&search_dir)?;
+
+        let search_path = format!("{}/index.html", search_dir);
+        let mut file = File::create(search_path)?;
+        write!(file, "{}", search_html)?;
+
+        Ok(())
+    }
+}

--- a/src/plugins/sitemap/mod.rs
+++ b/src/plugins/sitemap/mod.rs
@@ -45,6 +45,12 @@ impl Plugin for SitemapPlugin {
             ));
         }
 
+        // Add search page
+        url_entries.push_str(&format!(
+            "<url><loc>{}/search/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>",
+            host
+        ));
+
         // Build the complete sitemap XML
         let sitemap_xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">{}</urlset>"#,

--- a/src/plugins/sitemap/mod.rs
+++ b/src/plugins/sitemap/mod.rs
@@ -37,6 +37,14 @@ impl Plugin for SitemapPlugin {
             host
         ));
 
+        // Add all pages
+        for page in &site.pages {
+            url_entries.push_str(&format!(
+                "<url><loc>{}/{}/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>",
+                host, page.slug
+            ));
+        }
+
         // Build the complete sitemap XML
         let sitemap_xml = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">{}</urlset>"#,


### PR DESCRIPTION
This PR adds several features to bring rusty-smith closer to feature parity with the JS (metalsmith) version:

- Generic pages system - New `PagesPlugin` reads markdown from `pages/` directory, parses frontmatter, and generates static HTML pages (like about-me)
- Search page with embedded JSON - `SearchPlugin` generates a search page with all posts embedded as JSON for client-side filtering
- Draft/publish status - Posts with `publish: draft` in frontmatter are excluded from the build
- Light theme support - Posts with `lightTheme: true` get the `light-theme` CSS class on the body element
- Environment variables documented - Added `.env.example` with all required env vars including new `TWITTER_HANDLE`
- Custom permalink override - Posts can specify `permalink: custom-url` in frontmatter to override the auto-generated URL slug


## Architecture notes
- `pages/` directory is gitignored (like `posts/`), with `pages.example/` providing sample content
- Pages are stored in `Site.pages` for dynamic sitemap generation

All new features include unit tests